### PR TITLE
feat: 구글 oauth2 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'com.auth0:java-jwt:4.2.1'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/trendist/user_service/UserServiceApplication.java
+++ b/src/main/java/com/trendist/user_service/UserServiceApplication.java
@@ -2,8 +2,10 @@ package com.trendist.user_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/trendist/user_service/domain/tier/domain/Tier.java
+++ b/src/main/java/com/trendist/user_service/domain/tier/domain/Tier.java
@@ -1,0 +1,37 @@
+package com.trendist.user_service.domain.tier.domain;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity(name = "tier")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Tier {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "tier_id")
+	private UUID id;
+
+	@Column(name = "tier_name")
+	private String tierName;
+
+	@Column(name = "required_exp")
+	private Integer requiredExp;
+
+	@Column(name = "tier_image_url")
+	private String tierImageUrl;
+
+}

--- a/src/main/java/com/trendist/user_service/domain/tier/repository/TierRepository.java
+++ b/src/main/java/com/trendist/user_service/domain/tier/repository/TierRepository.java
@@ -1,0 +1,12 @@
+package com.trendist.user_service.domain.tier.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trendist.user_service.domain.tier.domain.Tier;
+
+public interface TierRepository extends JpaRepository<Tier, UUID> {
+	Optional<Tier> findByTierName(String tierName);
+}

--- a/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
+++ b/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.trendist.user_service.domain.user.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trendist.user_service.domain.user.dto.request.UserFirstLoginSetupRequest;
+import com.trendist.user_service.domain.user.dto.response.UserFirstLoginSetupResponse;
+import com.trendist.user_service.domain.user.service.UserService;
+import com.trendist.user_service.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+	private final UserService userService;
+
+	@PostMapping("/profile")
+	public ApiResponse<UserFirstLoginSetupResponse> setUserProfile(
+		@AuthenticationPrincipal String email,
+		@RequestBody UserFirstLoginSetupRequest request){
+		return ApiResponse.onSuccess(userService.setUserProfile(email,request));
+	}
+}

--- a/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
+++ b/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
@@ -2,7 +2,6 @@ package com.trendist.user_service.domain.user.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +22,7 @@ public class UserController {
 	@PostMapping("/profile")
 	public ApiResponse<UserFirstLoginSetupResponse> setUserProfile(
 		@AuthenticationPrincipal String email,
-		@RequestBody UserFirstLoginSetupRequest request){
-		return ApiResponse.onSuccess(userService.setUserProfile(email,request));
+		@RequestBody UserFirstLoginSetupRequest request) {
+		return ApiResponse.onSuccess(userService.setUserProfile(email, request));
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
+++ b/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.trendist.user_service.domain.user.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.trendist.user_service.domain.user.dto.request.UserFirstLoginSetupRequest;
 import com.trendist.user_service.domain.user.dto.response.UserFirstLoginSetupResponse;
+import com.trendist.user_service.domain.user.dto.response.UserProfileResponse;
 import com.trendist.user_service.domain.user.service.UserService;
 import com.trendist.user_service.global.response.ApiResponse;
 
@@ -24,5 +26,12 @@ public class UserController {
 		@AuthenticationPrincipal String email,
 		@RequestBody UserFirstLoginSetupRequest request) {
 		return ApiResponse.onSuccess(userService.setUserProfile(email, request));
+	}
+
+	@GetMapping("/profile")
+	public ApiResponse<UserProfileResponse> getUserProfile(
+		@AuthenticationPrincipal String email
+	) {
+		return ApiResponse.onSuccess(userService.getUserProfile(email));
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/domain/Keyword.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/Keyword.java
@@ -1,0 +1,8 @@
+package com.trendist.user_service.domain.user.domain;
+
+public enum Keyword {//게시글 키워드, 협의에 따른 수정 가능
+	Environment,
+	PeopleAndSociety,
+	Economy,
+	Technology
+}

--- a/src/main/java/com/trendist/user_service/domain/user/domain/User.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/User.java
@@ -50,10 +50,10 @@ public class User extends BaseTimeEntity {
 	@Column(name = "keyword")
 	private Set<Keyword> keyword;
 
-	/*@Column(name = "exp")
+	@Column(name = "exp")
 	@Builder.Default
 	private Integer exp = 0;
 
-	@Column(name="ranking")
+	/*@Column(name="ranking")
 	private Integer ranking;*/
 }

--- a/src/main/java/com/trendist/user_service/domain/user/domain/User.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/User.java
@@ -48,7 +48,7 @@ public class User extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	@CollectionTable(name = "user_keywords", joinColumns = @JoinColumn(name = "user_id"))
 	@Column(name = "keyword")
-	private Set<Keyword> keyword;
+	private Set<Keyword> keywords;
 
 	@Column(name = "exp")
 	@Builder.Default

--- a/src/main/java/com/trendist/user_service/domain/user/domain/User.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/User.java
@@ -6,8 +6,6 @@ import com.trendist.user_service.global.common.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;

--- a/src/main/java/com/trendist/user_service/domain/user/domain/User.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/User.java
@@ -3,6 +3,7 @@ package com.trendist.user_service.domain.user.domain;
 import java.util.Set;
 import java.util.UUID;
 
+import com.trendist.user_service.domain.tier.domain.Tier;
 import com.trendist.user_service.global.common.domain.BaseTimeEntity;
 
 import jakarta.persistence.CollectionTable;
@@ -16,6 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -57,6 +59,10 @@ public class User extends BaseTimeEntity {
 	@Column(name = "exp")
 	@Builder.Default
 	private Integer exp = 0;
+
+	@ManyToOne
+	@JoinColumn(name = "tier_id")
+	private Tier tier;
 
 	/*@Column(name="ranking")
 	private Integer ranking;*/

--- a/src/main/java/com/trendist/user_service/domain/user/domain/User.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/User.java
@@ -1,21 +1,30 @@
 package com.trendist.user_service.domain.user.domain;
 
+import java.util.Set;
 import java.util.UUID;
 
 import com.trendist.user_service.global.common.domain.BaseTimeEntity;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity(name = "users")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -32,14 +41,16 @@ public class User extends BaseTimeEntity {
 	@Column(name = "email")
 	private String email;
 
-	/*@Column(name = "nickname")
+	@Column(name = "nickname")
 	private String nickname;
 
+	@ElementCollection(fetch = FetchType.EAGER)
 	@Enumerated(EnumType.STRING)
+	@CollectionTable(name = "user_keywords", joinColumns = @JoinColumn(name = "user_id"))
 	@Column(name = "keyword")
-	private Keyword keyword;
+	private Set<Keyword> keyword;
 
-	@Column(name = "exp")
+	/*@Column(name = "exp")
 	@Builder.Default
 	private Integer exp = 0;
 

--- a/src/main/java/com/trendist/user_service/domain/user/domain/User.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/User.java
@@ -50,6 +50,10 @@ public class User extends BaseTimeEntity {
 	@Column(name = "keyword")
 	private Set<Keyword> keywords;
 
+	@Column(name = "is_joined")
+	@Builder.Default
+	private Boolean isJoined = false;
+
 	@Column(name = "exp")
 	@Builder.Default
 	private Integer exp = 0;

--- a/src/main/java/com/trendist/user_service/domain/user/domain/User.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/User.java
@@ -1,0 +1,50 @@
+package com.trendist.user_service.domain.user.domain;
+
+import java.util.UUID;
+
+import com.trendist.user_service.global.common.domain.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "user_id")
+	private UUID id;
+
+	@Column(name = "username")
+	private String username;
+
+	@Column(name = "email")
+	private String email;
+
+	/*@Column(name = "nickname")
+	private String nickname;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "keyword")
+	private Keyword keyword;
+
+	@Column(name = "exp")
+	@Builder.Default
+	private Integer exp = 0;
+
+	@Column(name="ranking")
+	private Integer ranking;*/
+}

--- a/src/main/java/com/trendist/user_service/domain/user/dto/request/UserFirstLoginSetupRequest.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/request/UserFirstLoginSetupRequest.java
@@ -1,0 +1,15 @@
+package com.trendist.user_service.domain.user.dto.request;
+
+import java.util.Set;
+
+import com.trendist.user_service.domain.user.domain.Keyword;
+
+import lombok.Builder;
+
+@Builder
+public record UserFirstLoginSetupRequest(
+	String nickname,
+	Set<Keyword> keywords
+) {
+
+}

--- a/src/main/java/com/trendist/user_service/domain/user/dto/response/UserFirstLoginSetupResponse.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/response/UserFirstLoginSetupResponse.java
@@ -15,8 +15,8 @@ public record UserFirstLoginSetupResponse(
 	String username,
 	String nickname,
 	Set<Keyword> keywords
-	) {
-	public static UserFirstLoginSetupResponse from(User user){
+) {
+	public static UserFirstLoginSetupResponse from(User user) {
 		return UserFirstLoginSetupResponse.builder()
 			.id(user.getId())
 			.email(user.getEmail())

--- a/src/main/java/com/trendist/user_service/domain/user/dto/response/UserFirstLoginSetupResponse.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/response/UserFirstLoginSetupResponse.java
@@ -14,7 +14,8 @@ public record UserFirstLoginSetupResponse(
 	String email,
 	String username,
 	String nickname,
-	Set<Keyword> keywords
+	Set<Keyword> keywords,
+	Boolean isJoined
 ) {
 	public static UserFirstLoginSetupResponse from(User user) {
 		return UserFirstLoginSetupResponse.builder()
@@ -23,6 +24,7 @@ public record UserFirstLoginSetupResponse(
 			.username(user.getUsername())
 			.nickname(user.getNickname())
 			.keywords(user.getKeywords())
+			.isJoined(user.getIsJoined())
 			.build();
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/dto/response/UserFirstLoginSetupResponse.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/response/UserFirstLoginSetupResponse.java
@@ -1,0 +1,28 @@
+package com.trendist.user_service.domain.user.dto.response;
+
+import java.util.Set;
+import java.util.UUID;
+
+import com.trendist.user_service.domain.user.domain.Keyword;
+import com.trendist.user_service.domain.user.domain.User;
+
+import lombok.Builder;
+
+@Builder
+public record UserFirstLoginSetupResponse(
+	UUID id,
+	String email,
+	String username,
+	String nickname,
+	Set<Keyword> keywords
+	) {
+	public static UserFirstLoginSetupResponse from(User user){
+		return UserFirstLoginSetupResponse.builder()
+			.id(user.getId())
+			.email(user.getEmail())
+			.username(user.getUsername())
+			.nickname(user.getNickname())
+			.keywords(user.getKeyword())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/user_service/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/response/UserProfileResponse.java
@@ -9,20 +9,22 @@ import com.trendist.user_service.domain.user.domain.User;
 import lombok.Builder;
 
 @Builder
-public record UserFirstLoginSetupResponse(
+public record UserProfileResponse(
 	UUID id,
-	String email,
 	String username,
+	String email,
 	String nickname,
-	Set<Keyword> keywords
+	Set<Keyword> keywords,
+	int exp
 ) {
-	public static UserFirstLoginSetupResponse from(User user) {
-		return UserFirstLoginSetupResponse.builder()
+	public static UserProfileResponse from(User user){
+		return UserProfileResponse.builder()
 			.id(user.getId())
-			.email(user.getEmail())
 			.username(user.getUsername())
+			.email(user.getEmail())
 			.nickname(user.getNickname())
 			.keywords(user.getKeywords())
+			.exp(user.getExp())
 			.build();
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/response/UserProfileResponse.java
@@ -15,9 +15,11 @@ public record UserProfileResponse(
 	String email,
 	String nickname,
 	Set<Keyword> keywords,
-	int exp
+	int exp,
+	String tierName,
+	String tierImageUrl
 ) {
-	public static UserProfileResponse from(User user){
+	public static UserProfileResponse from(User user) {
 		return UserProfileResponse.builder()
 			.id(user.getId())
 			.username(user.getUsername())
@@ -25,6 +27,8 @@ public record UserProfileResponse(
 			.nickname(user.getNickname())
 			.keywords(user.getKeywords())
 			.exp(user.getExp())
+			.tierName(user.getTier().getTierName())
+			.tierImageUrl(user.getTier().getTierImageUrl())
 			.build();
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/trendist/user_service/domain/user/repository/UserRepository.java
@@ -3,12 +3,10 @@ package com.trendist.user_service.domain.user.repository;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.trendist.user_service.domain.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-	Optional<User>findByEmail(String email);
+	Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/trendist/user_service/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/trendist/user_service/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.trendist.user_service.domain.user.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.trendist.user_service.domain.user.domain.User;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+	Optional<User>findByEmail(String email);
+}

--- a/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import com.trendist.user_service.domain.user.domain.User;
 import com.trendist.user_service.domain.user.dto.request.UserFirstLoginSetupRequest;
 import com.trendist.user_service.domain.user.dto.response.UserFirstLoginSetupResponse;
+import com.trendist.user_service.domain.user.dto.response.UserProfileResponse;
 import com.trendist.user_service.domain.user.repository.UserRepository;
 import com.trendist.user_service.global.exception.ApiException;
 import com.trendist.user_service.global.response.status.ErrorStatus;
@@ -23,9 +24,14 @@ public class UserService {
 		User user = getUser(email);
 
 		user.setNickname(userFirstLoginSetupRequest.nickname());
-		user.setKeyword(userFirstLoginSetupRequest.keywords());
+		user.setKeywords(userFirstLoginSetupRequest.keywords());
 
 		return UserFirstLoginSetupResponse.from(userRepository.save(user));
+	}
+
+	public UserProfileResponse getUserProfile(String email) {
+		User user = getUser(email);
+		return UserProfileResponse.from(user);
 	}
 
 	private User getUser(String email) {

--- a/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
@@ -23,8 +23,13 @@ public class UserService {
 		UserFirstLoginSetupRequest userFirstLoginSetupRequest) {
 		User user = getUser(email);
 
+		if (user.getIsJoined()) {
+			throw new ApiException(ErrorStatus._USER_NOT_FIRST_LOGIN);
+		}
+
 		user.setNickname(userFirstLoginSetupRequest.nickname());
 		user.setKeywords(userFirstLoginSetupRequest.keywords());
+		user.setIsJoined(true);
 
 		return UserFirstLoginSetupResponse.from(userRepository.save(user));
 	}

--- a/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 	private final UserRepository userRepository;
 
+	// 처음 로그인한 사용자의 경우 초기 정보 입력하는 로직
 	public UserFirstLoginSetupResponse setUserProfile(String email,
 		UserFirstLoginSetupRequest userFirstLoginSetupRequest) {
 		User user = getUser(email);
@@ -34,6 +35,7 @@ public class UserService {
 		return UserFirstLoginSetupResponse.from(userRepository.save(user));
 	}
 
+	//사용자의 프로필을 가지고 오는 로직
 	public UserProfileResponse getUserProfile(String email) {
 		User user = getUser(email);
 		return UserProfileResponse.from(user);

--- a/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
@@ -1,0 +1,35 @@
+package com.trendist.user_service.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import com.trendist.user_service.domain.user.domain.User;
+import com.trendist.user_service.domain.user.dto.request.UserFirstLoginSetupRequest;
+import com.trendist.user_service.domain.user.dto.response.UserFirstLoginSetupResponse;
+import com.trendist.user_service.domain.user.repository.UserRepository;
+import com.trendist.user_service.global.exception.ApiException;
+import com.trendist.user_service.global.response.status.ErrorStatus;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+	private final UserRepository userRepository;
+
+	public UserFirstLoginSetupResponse setUserProfile(String email,
+		UserFirstLoginSetupRequest userFirstLoginSetupRequest) {
+		User user = getUser(email);
+
+		user.setNickname(userFirstLoginSetupRequest.nickname());
+		user.setKeyword(userFirstLoginSetupRequest.keywords());
+
+		return UserFirstLoginSetupResponse.from(userRepository.save(user));
+	}
+
+	private User getUser(String email) {
+		return userRepository.findByEmail(email)
+			.orElseThrow(() -> new ApiException(ErrorStatus._USER_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/trendist/user_service/global/config/SecurityConfig.java
+++ b/src/main/java/com/trendist/user_service/global/config/SecurityConfig.java
@@ -1,0 +1,56 @@
+package com.trendist.user_service.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import com.trendist.user_service.global.jwt.OAuth2AuthenticationSuccessHandler;
+import com.trendist.user_service.global.jwt.filter.JwtAuthenticationFilter;
+import com.trendist.user_service.global.jwt.service.CustomOAuth2UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final CustomOAuth2UserService customOAuth2UserService;
+	private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+	@Bean
+	public WebSecurityCustomizer configure() {
+		return (web) -> web.ignoring()
+			.requestMatchers(new AntPathRequestMatcher("/static/**"));
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		return http
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+					"/oauth2/**", "/api/token"
+				).permitAll()
+				.anyRequest().authenticated())
+			.oauth2Login(oauth2 -> oauth2
+				.userInfoEndpoint(userInfo -> userInfo
+					.userService(customOAuth2UserService))
+				.successHandler(oAuth2AuthenticationSuccessHandler))
+			.csrf(AbstractHttpConfigurer::disable)
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			.build();
+	}
+
+	@Bean
+	public BCryptPasswordEncoder bCryptPasswordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+}

--- a/src/main/java/com/trendist/user_service/global/exception/ApiException.java
+++ b/src/main/java/com/trendist/user_service/global/exception/ApiException.java
@@ -6,18 +6,18 @@ import com.trendist.user_service.global.response.status.ErrorStatus;
 //발생하는 특정 오류 상황을 명시적으로 표현하기 위함.
 public class ApiException extends RuntimeException {
 
-  private final ErrorStatus errorStatus;
+	private final ErrorStatus errorStatus;
 
-  public ApiException(ErrorStatus errorStatus) {
-    super(errorStatus.getMessage());
-    this.errorStatus = errorStatus;
-  }
+	public ApiException(ErrorStatus errorStatus) {
+		super(errorStatus.getMessage());
+		this.errorStatus = errorStatus;
+	}
 
-  public ErrorReasonDto getErrorReason() {
-    return this.errorStatus.getReason();
-  }
+	public ErrorReasonDto getErrorReason() {
+		return this.errorStatus.getReason();
+	}
 
-  public ErrorReasonDto getErrorReasonHttpStatus() {
-    return this.errorStatus.getReasonHttpStatus();
-  }
+	public ErrorReasonDto getErrorReasonHttpStatus() {
+		return this.errorStatus.getReasonHttpStatus();
+	}
 }

--- a/src/main/java/com/trendist/user_service/global/jwt/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,50 @@
+package com.trendist.user_service.global.jwt;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trendist.user_service.domain.user.domain.User;
+import com.trendist.user_service.domain.user.repository.UserRepository;
+import com.trendist.user_service.global.exception.ApiException;
+import com.trendist.user_service.global.jwt.dto.JwtResponseDTO;
+import com.trendist.user_service.global.jwt.provider.TokenProvider;
+import com.trendist.user_service.global.response.ApiResponse;
+import com.trendist.user_service.global.response.status.ErrorStatus;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+	private final UserRepository userRepository;
+	private final TokenProvider tokenProvider;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
+		String email = oAuth2User.getAttribute("email");
+
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new ApiException(ErrorStatus._USER_NOT_FOUND));
+
+		String accessToken = tokenProvider.generateToken(user, Duration.ofHours(2));
+
+		response.setContentType("application/json;charset=UTF-8"); // UTF-8 인코딩 명시
+		response.setCharacterEncoding("UTF-8"); // 추가적으로 문자 인코딩 설정
+
+		ApiResponse<JwtResponseDTO> apiResponse = ApiResponse.onSuccess(
+			new JwtResponseDTO(user.getId(), user.getUsername(), accessToken)
+		);
+
+		new ObjectMapper().writeValue(response.getWriter(), apiResponse);
+	}
+}

--- a/src/main/java/com/trendist/user_service/global/jwt/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/OAuth2AuthenticationSuccessHandler.java
@@ -42,7 +42,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 		response.setCharacterEncoding("UTF-8"); // 추가적으로 문자 인코딩 설정
 
 		ApiResponse<JwtResponseDTO> apiResponse = ApiResponse.onSuccess(
-			new JwtResponseDTO(user.getId(), user.getUsername(), accessToken)
+			new JwtResponseDTO(user.getId(), user.getUsername(), user.getEmail(), accessToken)
 		);
 
 		new ObjectMapper().writeValue(response.getWriter(), apiResponse);

--- a/src/main/java/com/trendist/user_service/global/jwt/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/OAuth2AuthenticationSuccessHandler.java
@@ -42,7 +42,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
 		response.setCharacterEncoding("UTF-8"); // 추가적으로 문자 인코딩 설정
 
 		ApiResponse<JwtResponseDTO> apiResponse = ApiResponse.onSuccess(
-			new JwtResponseDTO(user.getId(), user.getUsername(), user.getEmail(), accessToken)
+			JwtResponseDTO.from(user, accessToken)
 		);
 
 		new ObjectMapper().writeValue(response.getWriter(), apiResponse);

--- a/src/main/java/com/trendist/user_service/global/jwt/dto/JwtProperties.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/dto/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.trendist.user_service.global.jwt.dto;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+	private String issuer;
+	private String secretKey;
+}

--- a/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
@@ -1,0 +1,18 @@
+package com.trendist.user_service.global.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JwtResponseDTO {
+	private Long userId;
+	private String name;
+	private String accessToken;
+}

--- a/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
@@ -15,6 +15,7 @@ import lombok.Setter;
 @Builder
 public class JwtResponseDTO {
 	private UUID userId;
-	private String name;
+	private String username;
+	private String email;
 	private String accessToken;
 }

--- a/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
@@ -1,5 +1,7 @@
 package com.trendist.user_service.global.jwt.dto;
 
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +14,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class JwtResponseDTO {
-	private Long userId;
+	private UUID userId;
 	private String name;
 	private String accessToken;
 }

--- a/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
@@ -4,11 +4,7 @@ import java.util.UUID;
 
 import com.trendist.user_service.domain.user.domain.User;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Builder
 public record JwtResponseDTO(

--- a/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/dto/JwtResponseDTO.java
@@ -2,20 +2,27 @@ package com.trendist.user_service.global.jwt.dto;
 
 import java.util.UUID;
 
+import com.trendist.user_service.domain.user.domain.User;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
-public class JwtResponseDTO {
-	private UUID userId;
-	private String username;
-	private String email;
-	private String accessToken;
+public record JwtResponseDTO(
+	UUID userId,
+	String username,
+	String email,
+	String accessToken
+) {
+	public static JwtResponseDTO from(User user, String accessToken) {
+		return JwtResponseDTO.builder()
+			.userId(user.getId())
+			.username(user.getUsername())
+			.email(user.getEmail())
+			.accessToken(accessToken)
+			.build();
+	}
 }

--- a/src/main/java/com/trendist/user_service/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.trendist.user_service.global.jwt.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.trendist.user_service.global.jwt.provider.TokenProvider;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	private final TokenProvider tokenProvider;
+	private final static String HEADER_AUTHORIZATION = "Authorization";
+	private final static String TOKEN_PREFIX = "Bearer";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+		String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+		String token = getAccessToken(authorizationHeader);
+
+		if (tokenProvider.validToken(token)) {
+			Authentication authentication = tokenProvider.getAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private String getAccessToken(String authorizationHeader) {
+		if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+			return authorizationHeader.substring(TOKEN_PREFIX.length());
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/trendist/user_service/global/jwt/provider/TokenProvider.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/provider/TokenProvider.java
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TokenProvider {
 	private final JwtProperties jwtProperties;
-	Key key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
 
 	public String generateToken(User user, Duration expiredAt) {
 		Date now = new Date();
@@ -35,6 +34,7 @@ public class TokenProvider {
 
 	private String makeToken(Date expiry, User user) {
 		Date now = new Date();
+		Key key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
 
 		return Jwts.builder()
 			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
@@ -48,6 +48,7 @@ public class TokenProvider {
 	}
 
 	public boolean validToken(String token) {
+		Key key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
 
 		try {
 			Jwts.parserBuilder()
@@ -68,6 +69,7 @@ public class TokenProvider {
 	}
 
 	private Claims getClaims(String token) {
+		Key key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
 
 		return Jwts.parserBuilder()
 			.setSigningKey(key)

--- a/src/main/java/com/trendist/user_service/global/jwt/provider/TokenProvider.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/provider/TokenProvider.java
@@ -1,0 +1,78 @@
+package com.trendist.user_service.global.jwt.provider;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import com.trendist.user_service.domain.user.domain.User;
+import com.trendist.user_service.global.jwt.dto.JwtProperties;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenProvider {
+	private final JwtProperties jwtProperties;
+	Key key = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+
+	public String generateToken(User user, Duration expiredAt) {
+		Date now = new Date();
+		return makeToken(new Date(now.getTime() + expiredAt.toMillis()), user);
+	}
+
+	private String makeToken(Date expiry, User user) {
+		Date now = new Date();
+
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setIssuer(jwtProperties.getIssuer())
+			.setIssuedAt(now)
+			.setExpiration(expiry)
+			.setSubject(user.getEmail())
+			.claim("id", user.getId())
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public boolean validToken(String token) {
+
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	public Authentication getAuthentication(String token) {
+		Claims claims = getClaims(token);
+		String email = claims.getSubject();//@AuthenticationPrincipal 사용을 위해 필수
+		Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+		return new UsernamePasswordAuthenticationToken(email, token, authorities);
+	}
+
+	private Claims getClaims(String token) {
+
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+}

--- a/src/main/java/com/trendist/user_service/global/jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/service/CustomOAuth2UserService.java
@@ -12,8 +12,12 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import com.trendist.user_service.domain.tier.domain.Tier;
+import com.trendist.user_service.domain.tier.repository.TierRepository;
 import com.trendist.user_service.domain.user.domain.User;
 import com.trendist.user_service.domain.user.repository.UserRepository;
+import com.trendist.user_service.global.exception.ApiException;
+import com.trendist.user_service.global.response.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 	private final UserRepository userRepository;
+	private final TierRepository tierRepository;
 
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -39,9 +44,14 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
 		User user = userRepository.findByEmail(email)
 			.orElseGet(() -> {
+				Tier tier = tierRepository.findByTierName("초보 여행자")
+					.orElseThrow(() -> new ApiException(ErrorStatus._TIER_NOT_FOUND));
+
 				User newUser = User.builder()
 					.email(email)
 					.username(username)
+					.isJoined(false)
+					.tier(tier)
 					.build();
 				return userRepository.save(newUser);
 			});

--- a/src/main/java/com/trendist/user_service/global/jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/service/CustomOAuth2UserService.java
@@ -1,0 +1,53 @@
+package com.trendist.user_service.global.jwt.service;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.trendist.user_service.domain.user.domain.User;
+import com.trendist.user_service.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+	private final UserRepository userRepository;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2UserService<OAuth2UserRequest,OAuth2User> oauth=new DefaultOAuth2UserService();
+		OAuth2User oAuth2User=oauth.loadUser(userRequest);
+
+		String registrationId = userRequest.getClientRegistration().getRegistrationId();
+		String userNameAttributeName=userRequest.getClientRegistration()
+			.getProviderDetails()
+			.getUserInfoEndpoint()
+			.getUserNameAttributeName();
+
+		Map<String,Object> attributes=oAuth2User.getAttributes();
+		String email=(String)attributes.get("email");
+		String username=(String)attributes.get("name");
+
+		User user=userRepository.findByEmail(email)
+			.orElseGet(()->{
+				User newUser=User.builder()
+					.email(email)
+					.username(username)
+					.build();
+				return userRepository.save(newUser);
+			});
+		return new DefaultOAuth2User(
+			Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+			attributes,
+			userNameAttributeName);
+	}
+}

--- a/src/main/java/com/trendist/user_service/global/jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/trendist/user_service/global/jwt/service/CustomOAuth2UserService.java
@@ -24,22 +24,22 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
 	@Override
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-		OAuth2UserService<OAuth2UserRequest,OAuth2User> oauth=new DefaultOAuth2UserService();
-		OAuth2User oAuth2User=oauth.loadUser(userRequest);
+		OAuth2UserService<OAuth2UserRequest, OAuth2User> oauth = new DefaultOAuth2UserService();
+		OAuth2User oAuth2User = oauth.loadUser(userRequest);
 
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
-		String userNameAttributeName=userRequest.getClientRegistration()
+		String userNameAttributeName = userRequest.getClientRegistration()
 			.getProviderDetails()
 			.getUserInfoEndpoint()
 			.getUserNameAttributeName();
 
-		Map<String,Object> attributes=oAuth2User.getAttributes();
-		String email=(String)attributes.get("email");
-		String username=(String)attributes.get("name");
+		Map<String, Object> attributes = oAuth2User.getAttributes();
+		String email = (String)attributes.get("email");
+		String username = (String)attributes.get("name");
 
-		User user=userRepository.findByEmail(email)
-			.orElseGet(()->{
-				User newUser=User.builder()
+		User user = userRepository.findByEmail(email)
+			.orElseGet(() -> {
+				User newUser = User.builder()
 					.email(email)
 					.username(username)
 					.build();

--- a/src/main/java/com/trendist/user_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/user_service/global/response/status/ErrorStatus.java
@@ -20,10 +20,11 @@ public enum ErrorStatus implements BaseErrorCode {
 	_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
 	_JWT_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT_001", "Header에 JWT가 존재하지 않습니다."),
-	_GITHUB_TOKEN_GENERATION_ERROR(HttpStatus.NOT_FOUND, "JWT_002", "깃허브에서 엑세스 토큰을 발급하는 과정에서 오류가 발생했습니다."),
 
 	_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 존재하지 않습니다"),
-	_USER_NOT_FIRST_LOGIN(HttpStatus.BAD_REQUEST, "USER_002", "최초 로그인한 유저가 아닙니다.");
+	_USER_NOT_FIRST_LOGIN(HttpStatus.BAD_REQUEST, "USER_002", "최초 로그인한 유저가 아닙니다."),
+
+	_TIER_NOT_FOUND(HttpStatus.NOT_FOUND, "TIER_001", "해당 티어를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/trendist/user_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/user_service/global/response/status/ErrorStatus.java
@@ -22,8 +22,8 @@ public enum ErrorStatus implements BaseErrorCode {
 	_JWT_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT_001", "Header에 JWT가 존재하지 않습니다."),
 	_GITHUB_TOKEN_GENERATION_ERROR(HttpStatus.NOT_FOUND, "JWT_002", "깃허브에서 엑세스 토큰을 발급하는 과정에서 오류가 발생했습니다."),
 
-	_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 존재하지 않습니다");
-
+	_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 존재하지 않습니다"),
+	_USER_NOT_FIRST_LOGIN(HttpStatus.BAD_REQUEST, "USER_002", "최초 로그인한 유저가 아닙니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/trendist/user_service/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/trendist/user_service/global/response/status/ErrorStatus.java
@@ -17,7 +17,13 @@ public enum ErrorStatus implements BaseErrorCode {
 	_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
 	_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
 	_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-	_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+	_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+	_JWT_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT_001", "Header에 JWT가 존재하지 않습니다."),
+	_GITHUB_TOKEN_GENERATION_ERROR(HttpStatus.NOT_FOUND, "JWT_002", "깃허브에서 엑세스 토큰을 발급하는 과정에서 오류가 발생했습니다."),
+
+	_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 존재하지 않습니다");
+
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
             scope:
               - email
               - profile
-            redirect-uri: "http://localhost:8080/login"
+            redirect-uri: "http://localhost:8080/login/oauth2/code/google"
             client-name: google
         provider:
           google:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/trendist
+    username: root
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,5 +34,5 @@ spring:
             user-name-attribute: sub
 
 jwt:
-  issuer: test@naver.com
-  secret_key: study-jwtloginregister
+  issuer: ${ISSUER}
+  secret_key: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,35 @@ spring:
     username: root
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+    defer-datasource-initialization: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${CLIENT_ID}
+            client-secret: ${CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+            redirect-uri: "http://localhost:8080/login"
+            client-name: google
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+
+jwt:
+  issuer: test@naver.com
+  secret_key: study-jwtloginregister

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/trendist
+    url: ${DB_URL}
     username: root
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,10 @@ spring:
         use_sql_comments: true
     defer-datasource-initialization: true
 
+  sql:
+    init:
+      mode: always
+
   security:
     oauth2:
       client:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,5 @@
+INSERT INTO tier(tier_id, tier_name, required_exp, tier_image_url)
+VALUES (UNHEX(REPLACE(UUID(), '-', '')), '초보 여행자', 0, 'noviceTravelerUrl'),
+       (UNHEX(REPLACE(UUID(), '-', '')), '프로 탐험가', 50, 'proTravelerUrl'),
+       (UNHEX(REPLACE(UUID(), '-', '')), '글로벌 마스터', 150, 'GlobalMasterUrl'),
+       (UNHEX(REPLACE(UUID(), '-', '')), '유니버스 리더', 300, 'UniverseLeaderUrl');


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**- 구글 oauth2를 이용한 로그인 기능을 구현하였습니다.**
- 해당 기능의 경우 회원가입이 진행되는 것이 아닌 구글을 통한 로그인을 진행하고 사용자의 정보를 저장합니다.

**- 최초 로그인한 사용자의 경우 초기 정보인 닉네임과 키워드를 입력하도록 구현하였습니다.**

**- 티어 테이블을 만들어 미리 데이터베이스에 티어값을 집어넣고 최초 로그인한 사용자는 초보 여행자로 티어를 설정하도록 구현하였습니다.**

**- 테스트 방법**
1. localhost:8080으로 접속할 시 다음 사진과 같이 화면으로 넘어가지게 되고 로그인을 진행합니다.
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/14e42a19-c113-4509-a367-6b03d4555b53" />

2. 로그인에 성공하면 다음과 같이 화면이 나오게 되고 accessToken이 있는 것을 확인할 수 있습니다. 여기서 accessToken의 경우 모든 기능을 수행할 수 있도록 해주는 토큰이기에 기억해둡니다. 
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/daec61f7-4000-4a01-8c29-dfdc553f3171" />

3. 포스트맨으로 들어가 POST http://localhost:8080/users/profile 주소를 작성합니다. 그리고 Auth->Bear Token에 accessToken을 집어넣습니다. 그리고 Body->JSON을 통해 nickname과 keywords를 다음과 같이 입력합니다. 그리고 Send 버튼을 누를 경우 정보 입력에 성공한 것을 확인할 수 있습니다.
```
{
  "nickname": "승현",
  "keywords": ["Environment", "Economy"]
}
``` 
<img width="769" alt="image" src="https://github.com/user-attachments/assets/8eaaf360-f6a6-41fa-a633-f26ee53a5ab0" />
<img width="768" alt="image" src="https://github.com/user-attachments/assets/70a3eac6-0bfd-461b-b9de-39f31d99363b" />
<img width="771" alt="image" src="https://github.com/user-attachments/assets/86dc39cd-8915-49e8-a4f6-c5a68c0ed155" />



---

## 🔗 관련 이슈
- close #3 

---

## 💡 추가 사항
현재 프로필 이미지는 구현하지 않았습니다. 왜냐하면 현재 aws s3를 사용할지 아니면 카카오 클라우드의 object storage를 사용할지 고민중이기 때문입니다. 이 부분은 같이 고민해보고 결정하는 것이 좋을 것 같습니다.

