### PR TITLE
feat: 사용자 관련 api 구현

### DIFF
--- a/src/main/java/com/trendist/user_service/UserServiceApplication.java
+++ b/src/main/java/com/trendist/user_service/UserServiceApplication.java
@@ -3,9 +3,11 @@ package com.trendist.user_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
+++ b/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
@@ -1,7 +1,10 @@
 package com.trendist.user_service.domain.user.controller;
 
+import java.util.UUID;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,9 +41,18 @@ public class UserController {
 		description = "로그인한 본인의 프로필을 조회합니다."
 	)
 	@GetMapping("/profile")
-	public ApiResponse<UserProfileResponse> getUserProfile(
+	public ApiResponse<UserProfileResponse> getMyProfile(
 		@AuthenticationPrincipal String email
 	) {
-		return ApiResponse.onSuccess(userService.getUserProfile(email));
+		return ApiResponse.onSuccess(userService.getMyProfile(email));
+	}
+
+	@Operation(
+		summary = "특정 사용자의 프로필 조회",
+		description = "특정 사용자의 프로필을 조회합니다."
+	)
+	@GetMapping("/profile/{userId}")
+	public ApiResponse<UserProfileResponse> getUserProfile(@PathVariable(name = "userId") UUID userId) {
+		return ApiResponse.onSuccess(userService.getUserProfile(userId));
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
+++ b/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.trendist.user_service.domain.user.controller;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.trendist.user_service.domain.user.dto.request.UserFirstLoginSetupRequest;
 import com.trendist.user_service.domain.user.dto.request.UserProfileUpdateRequest;
+import com.trendist.user_service.domain.user.dto.response.RankingResponse;
 import com.trendist.user_service.domain.user.dto.response.UserFirstLoginSetupResponse;
 import com.trendist.user_service.domain.user.dto.response.UserProfileResponse;
 import com.trendist.user_service.domain.user.dto.response.UserProfileUpdateResponse;
@@ -68,5 +70,14 @@ public class UserController {
 	@GetMapping("/profile/{userId}")
 	public ApiResponse<UserProfileResponse> getUserProfile(@PathVariable(name = "userId") UUID userId) {
 		return ApiResponse.onSuccess(userService.getUserProfile(userId));
+	}
+
+	@Operation(
+		summary = "랭킹 조회",
+		description = "사용자들의 랭킹을 조회합니다."
+	)
+	@GetMapping("/rankings")
+	public ApiResponse<List<RankingResponse>> getRanking() {
+		return ApiResponse.onSuccess(userService.getRanking());
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
+++ b/src/main/java/com/trendist/user_service/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,8 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.trendist.user_service.domain.user.dto.request.UserFirstLoginSetupRequest;
+import com.trendist.user_service.domain.user.dto.request.UserProfileUpdateRequest;
 import com.trendist.user_service.domain.user.dto.response.UserFirstLoginSetupResponse;
 import com.trendist.user_service.domain.user.dto.response.UserProfileResponse;
+import com.trendist.user_service.domain.user.dto.response.UserProfileUpdateResponse;
 import com.trendist.user_service.domain.user.service.UserService;
 import com.trendist.user_service.global.response.ApiResponse;
 
@@ -34,6 +37,17 @@ public class UserController {
 		@AuthenticationPrincipal String email,
 		@RequestBody UserFirstLoginSetupRequest request) {
 		return ApiResponse.onSuccess(userService.setUserProfile(email, request));
+	}
+
+	@Operation(
+		summary = "사용자 프로필 수정",
+		description = "사용자 프로필을 수정합니다."
+	)
+	@PatchMapping("/profile/update")
+	public ApiResponse<UserProfileUpdateResponse> updateProfile(
+		@AuthenticationPrincipal String email,
+		@RequestBody UserProfileUpdateRequest userProfileUpdateRequest) {
+		return ApiResponse.onSuccess(userService.updateProfile(email, userProfileUpdateRequest));
 	}
 
 	@Operation(

--- a/src/main/java/com/trendist/user_service/domain/user/domain/User.java
+++ b/src/main/java/com/trendist/user_service/domain/user/domain/User.java
@@ -62,6 +62,7 @@ public class User extends BaseTimeEntity {
 	@JoinColumn(name = "tier_id")
 	private Tier tier;
 
-	/*@Column(name="ranking")
-	private Integer ranking;*/
+	@Column(name = "ranking")
+	@Builder.Default
+	private Integer ranking = 0;
 }

--- a/src/main/java/com/trendist/user_service/domain/user/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.trendist.user_service.domain.user.dto.request;
+
+import com.trendist.user_service.domain.user.domain.Keyword;
+
+import lombok.Builder;
+
+@Builder
+public record UserProfileUpdateRequest(
+	String nickname,
+	Keyword keyword,
+	String profileUrl
+) {
+}

--- a/src/main/java/com/trendist/user_service/domain/user/dto/response/RankingResponse.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/response/RankingResponse.java
@@ -1,0 +1,26 @@
+package com.trendist.user_service.domain.user.dto.response;
+
+import java.util.UUID;
+
+import com.trendist.user_service.domain.user.domain.User;
+
+import lombok.Builder;
+
+@Builder
+public record RankingResponse(
+	int ranking,
+	UUID id,
+	String nickname,
+	String profileUrl,
+	int exp
+) {
+	public static RankingResponse from(User user) {
+		return RankingResponse.builder()
+			.ranking(user.getRanking())
+			.id(user.getId())
+			.nickname(user.getNickname())
+			.profileUrl(user.getProfileUrl())
+			.exp(user.getExp())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/user_service/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/response/UserProfileResponse.java
@@ -17,7 +17,8 @@ public record UserProfileResponse(
 	String profileUrl,
 	int exp,
 	String tierName,
-	String tierImageUrl
+	String tierImageUrl,
+	int ranking
 ) {
 	public static UserProfileResponse from(User user) {
 		return UserProfileResponse.builder()
@@ -30,6 +31,7 @@ public record UserProfileResponse(
 			.exp(user.getExp())
 			.tierName(user.getTier().getTierName())
 			.tierImageUrl(user.getTier().getTierImageUrl())
+			.ranking(user.getRanking())
 			.build();
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/dto/response/UserProfileUpdateResponse.java
+++ b/src/main/java/com/trendist/user_service/domain/user/dto/response/UserProfileUpdateResponse.java
@@ -1,0 +1,25 @@
+package com.trendist.user_service.domain.user.dto.response;
+
+import java.util.UUID;
+
+import com.trendist.user_service.domain.user.domain.Keyword;
+import com.trendist.user_service.domain.user.domain.User;
+
+import lombok.Builder;
+
+@Builder
+public record UserProfileUpdateResponse(
+	UUID id,
+	String nickname,
+	Keyword keyword,
+	String profileUrl
+) {
+	public static UserProfileUpdateResponse from(User user) {
+		return UserProfileUpdateResponse.builder()
+			.id(user.getId())
+			.nickname(user.getNickname())
+			.keyword(user.getKeyword())
+			.profileUrl(user.getProfileUrl())
+			.build();
+	}
+}

--- a/src/main/java/com/trendist/user_service/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/trendist/user_service/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import com.trendist.user_service.domain.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
 	Optional<User> findByEmail(String email);
+
+	Optional<User> findById(UUID userId);
 }

--- a/src/main/java/com/trendist/user_service/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/trendist/user_service/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.trendist.user_service.domain.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +12,8 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 	Optional<User> findByEmail(String email);
 
 	Optional<User> findById(UUID userId);
+
+	List<User> findAllByOrderByExpDesc();
+
+	List<User> findAllByRankingGreaterThanOrderByRankingAsc(int ranking);
 }

--- a/src/main/java/com/trendist/user_service/domain/user/service/RankingScheduler.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/RankingScheduler.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class RankingScheduler {
 	private final UserRepository userRepository;
 
-	@Scheduled(cron = " 0 00 00 * * *")
+	@Scheduled(cron = "0 0 0 * * *")
 	@Transactional
 	public void updateUserRanking() {
 		List<User> users = userRepository.findAllByOrderByExpDesc();

--- a/src/main/java/com/trendist/user_service/domain/user/service/RankingScheduler.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/RankingScheduler.java
@@ -1,0 +1,47 @@
+package com.trendist.user_service.domain.user.service;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.trendist.user_service.domain.user.domain.User;
+import com.trendist.user_service.domain.user.repository.UserRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RankingScheduler {
+	private final UserRepository userRepository;
+
+	@Scheduled(cron = " 0 00 00 * * *")
+	@Transactional
+	public void updateUserRanking() {
+		List<User> users = userRepository.findAllByOrderByExpDesc();
+
+		int currentRanking = 1;
+		int position = 1;
+		Integer prevExp = null;
+
+		for (User user : users) {
+			Integer exp = user.getExp();
+
+			if (exp == 0) {
+				user.setRanking(0);
+				position++;
+				continue;
+			}
+
+			if (!exp.equals(prevExp)) {
+				currentRanking = position;
+			}
+
+			user.setRanking(currentRanking);
+			prevExp = exp;
+			position++;
+		}
+		userRepository.saveAll(users);
+	}
+}

--- a/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 
 import com.trendist.user_service.domain.user.domain.User;
 import com.trendist.user_service.domain.user.dto.request.UserFirstLoginSetupRequest;
+import com.trendist.user_service.domain.user.dto.request.UserProfileUpdateRequest;
 import com.trendist.user_service.domain.user.dto.response.UserFirstLoginSetupResponse;
 import com.trendist.user_service.domain.user.dto.response.UserProfileResponse;
+import com.trendist.user_service.domain.user.dto.response.UserProfileUpdateResponse;
 import com.trendist.user_service.domain.user.repository.UserRepository;
 import com.trendist.user_service.global.exception.ApiException;
 import com.trendist.user_service.global.response.status.ErrorStatus;
@@ -40,6 +42,18 @@ public class UserService {
 		}
 
 		return UserFirstLoginSetupResponse.from(userRepository.save(user));
+	}
+
+	public UserProfileUpdateResponse updateProfile(String email,
+		UserProfileUpdateRequest userProfileUpdateRequest) {
+		User user = getUser(email);
+
+		//기본값으로 원래 설정되어있던 값들이 설정되어있기에 전부 바꿔야함.
+		user.setNickname(userProfileUpdateRequest.nickname());
+		user.setKeyword(userProfileUpdateRequest.keyword());
+		user.setProfileUrl(userProfileUpdateRequest.profileUrl());
+
+		return UserProfileUpdateResponse.from(userRepository.save(user));
 	}
 
 	//본인의 프로필을 가지고 오는 로직

--- a/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.trendist.user_service.domain.user.service;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 
 import com.trendist.user_service.domain.user.domain.User;
@@ -40,14 +42,25 @@ public class UserService {
 		return UserFirstLoginSetupResponse.from(userRepository.save(user));
 	}
 
-	//사용자의 프로필을 가지고 오는 로직
-	public UserProfileResponse getUserProfile(String email) {
+	//본인의 프로필을 가지고 오는 로직
+	public UserProfileResponse getMyProfile(String email) {
 		User user = getUser(email);
+		return UserProfileResponse.from(user);
+	}
+
+	//특정 사용자의 프로필을 가지고 오는 로직
+	public UserProfileResponse getUserProfile(UUID userId) {
+		User user = getUser(userId);
 		return UserProfileResponse.from(user);
 	}
 
 	private User getUser(String email) {
 		return userRepository.findByEmail(email)
+			.orElseThrow(() -> new ApiException(ErrorStatus._USER_NOT_FOUND));
+	}
+
+	private User getUser(UUID userId) {
+		return userRepository.findById(userId)
 			.orElseThrow(() -> new ApiException(ErrorStatus._USER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
+++ b/src/main/java/com/trendist/user_service/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.trendist.user_service.domain.user.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -7,6 +8,7 @@ import org.springframework.stereotype.Service;
 import com.trendist.user_service.domain.user.domain.User;
 import com.trendist.user_service.domain.user.dto.request.UserFirstLoginSetupRequest;
 import com.trendist.user_service.domain.user.dto.request.UserProfileUpdateRequest;
+import com.trendist.user_service.domain.user.dto.response.RankingResponse;
 import com.trendist.user_service.domain.user.dto.response.UserFirstLoginSetupResponse;
 import com.trendist.user_service.domain.user.dto.response.UserProfileResponse;
 import com.trendist.user_service.domain.user.dto.response.UserProfileUpdateResponse;
@@ -66,6 +68,13 @@ public class UserService {
 	public UserProfileResponse getUserProfile(UUID userId) {
 		User user = getUser(userId);
 		return UserProfileResponse.from(user);
+	}
+
+	public List<RankingResponse> getRanking() {
+		return userRepository.findAllByRankingGreaterThanOrderByRankingAsc(0)
+			.stream()
+			.map(RankingResponse::from)
+			.toList();
 	}
 
 	private User getUser(String email) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**특정 사용자의 프로필을 조회하는 api를 구현하였습니다.**
<img width="830" alt="image" src="https://github.com/user-attachments/assets/cf676e4c-c168-412f-b08e-ee0a508e488d" />

**사용자의 프로필을 수정하는 api를 구현하였습니다.**
- 프로필 수정의 경우 닉네임, 키워드, 프로필 이미지를 수정할 수 있습니다.
<img width="828" alt="image" src="https://github.com/user-attachments/assets/90f0ab81-d0be-4f2c-b7b5-253e15c794f4" />

**사용자들의 랭킹을 업데이트하고 조회하는 기능을 구현하였습니다.**
- 랭킹 업데이트의 경우 스케줄러를 통해 매일 자정에 업데이트되게 하였습니다.
- 만약 경험치가 동일할 경우 동일 랭킹을 부여하고 그 다음 사람에게 그만큼 후순위의 랭킹을 부여합니다.
- 만약 경험치가 0일 경우 랭킹은 0이며 조회 시 나타나지 않도록 구현했습니다.
<img width="831" alt="image" src="https://github.com/user-attachments/assets/92cc20c0-fd66-41a8-a676-a3df11f7ed3e" />
 
---

## 🔗 관련 이슈
- close #11 

---

## 💡 추가 사항

